### PR TITLE
Implement inventory API backend

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,47 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+// Connect to SQLite database file (will create the file if it doesn't exist)
+const db = new sqlite3.Database(path.join(__dirname, 'inventory.db'), (err) => {
+  if (err) {
+    console.error('Failed to connect to database:', err.message);
+  } else {
+    console.log('Connected to SQLite database');
+  }
+});
+
+// Create the inventory table if it doesn't exist
+const createTableQuery = `CREATE TABLE IF NOT EXISTS inventory (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  category TEXT,
+  quantity INTEGER,
+  unit TEXT,
+  restock_threshold INTEGER,
+  supplier TEXT
+)`;
+
+// Ensure the table exists and populate it with sample data on first run
+// `serialize` ensures that the queries run sequentially
+
+db.serialize(() => {
+  db.run(createTableQuery);
+
+  db.get('SELECT COUNT(*) AS count FROM inventory', (err, row) => {
+    if (err) {
+      console.error('Error counting inventory rows:', err.message);
+      return;
+    }
+    if (row.count === 0) {
+      const insertStmt = db.prepare(
+        'INSERT INTO inventory (name, category, quantity, unit, restock_threshold, supplier) VALUES (?, ?, ?, ?, ?, ?)'
+      );
+      insertStmt.run('Pens', 'Office Supplies', 100, 'pack', 20, 'Staples');
+      insertStmt.run('Printer Paper', 'Office Supplies', 500, 'ream', 100, 'Office Depot');
+      insertStmt.run('Ink Toner', 'Printing', 10, 'cartridge', 2, 'HP');
+      insertStmt.finalize();
+    }
+  });
+});
+
+module.exports = db;

--- a/server/index.js
+++ b/server/index.js
@@ -1,9 +1,14 @@
 const express = require('express');
 const cors = require('cors');
+// Import inventory routes
+const inventoryRoutes = require('./routes/inventory');
 
 const app = express();
-app.use(cors());
-app.use(express.json());
+app.use(cors()); // Enable Cross-Origin Resource Sharing
+app.use(express.json()); // Parse incoming JSON bodies
+
+// Mount the inventory API routes
+app.use('/inventory', inventoryRoutes);
 
 const PORT = 5000;
 
@@ -11,6 +16,7 @@ app.get('/', (req, res) => {
   res.send('Office Inventory Backend Running');
 });
 
+// Start the Express server
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });

--- a/server/routes/inventory.js
+++ b/server/routes/inventory.js
@@ -1,0 +1,79 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../db');
+
+// Helper functions to use sqlite3 with Promises
+const runAsync = (sql, params = []) =>
+  new Promise((resolve, reject) => {
+    db.run(sql, params, function (err) {
+      if (err) return reject(err);
+      resolve(this);
+    });
+  });
+
+const allAsync = (sql, params = []) =>
+  new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+
+// GET /inventory -> returns all inventory items
+router.get('/', async (req, res) => {
+  try {
+    const rows = await allAsync('SELECT * FROM inventory');
+    res.json(rows);
+  } catch (err) {
+    console.error('Failed to retrieve items:', err.message);
+    res.status(500).json({ error: 'Failed to retrieve inventory' });
+  }
+});
+
+// POST /inventory -> insert a new item
+router.post('/', async (req, res) => {
+  const { name, category, quantity, unit, restock_threshold, supplier } = req.body;
+  try {
+    const query = `INSERT INTO inventory (name, category, quantity, unit, restock_threshold, supplier)
+                   VALUES (?, ?, ?, ?, ?, ?)`;
+    const result = await runAsync(query, [name, category, quantity, unit, restock_threshold, supplier]);
+    res.status(201).json({ id: result.lastID });
+  } catch (err) {
+    console.error('Failed to insert item:', err.message);
+    res.status(500).json({ error: 'Failed to add item' });
+  }
+});
+
+// PUT /inventory/:id -> update an item
+router.put('/:id', async (req, res) => {
+  const { id } = req.params;
+  const { name, category, quantity, unit, restock_threshold, supplier } = req.body;
+  try {
+    const query = `UPDATE inventory SET name=?, category=?, quantity=?, unit=?, restock_threshold=?, supplier=? WHERE id=?`;
+    const result = await runAsync(query, [name, category, quantity, unit, restock_threshold, supplier, id]);
+    if (result.changes === 0) {
+      return res.status(404).json({ error: 'Item not found' });
+    }
+    res.json({ updated: result.changes });
+  } catch (err) {
+    console.error('Failed to update item:', err.message);
+    res.status(500).json({ error: 'Failed to update item' });
+  }
+});
+
+// DELETE /inventory/:id -> delete an item
+router.delete('/:id', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const result = await runAsync('DELETE FROM inventory WHERE id=?', [id]);
+    if (result.changes === 0) {
+      return res.status(404).json({ error: 'Item not found' });
+    }
+    res.json({ deleted: result.changes });
+  } catch (err) {
+    console.error('Failed to delete item:', err.message);
+    res.status(500).json({ error: 'Failed to delete item' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- build a SQLite database initializer
- add inventory API routes with CRUD operations
- wire routes into the Express server

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687b093a78788331b6ea1b0577f0984e