### PR TITLE
Add edit modal to inventory table

### DIFF
--- a/client/src/InventoryTable.css
+++ b/client/src/InventoryTable.css
@@ -9,3 +9,21 @@
 .inventory-table th {
   background-color: #f2f2f2;
 }
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-content {
+  background: white;
+  padding: 1rem;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- allow updating inventory items in a new edit modal

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b16ce91448331b2a941c3901b51a7