### PR TITLE
Add validation and error handling

### DIFF
--- a/server/routes/inventory.js
+++ b/server/routes/inventory.js
@@ -11,6 +11,14 @@ const runAsync = (sql, params = []) =>
     });
   });
 
+const getAsync = (sql, params = []) =>
+  new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => {
+      if (err) return reject(err);
+      resolve(row);
+    });
+  });
+
 const allAsync = (sql, params = []) =>
   new Promise((resolve, reject) => {
     db.all(sql, params, (err, rows) => {
@@ -19,6 +27,17 @@ const allAsync = (sql, params = []) =>
     });
   });
 
+const isValidItem = (name, quantity, restock_threshold) => {
+  if (typeof name !== 'string' || name.trim() === '') return false;
+  if (typeof quantity !== 'number' || quantity < 0) return false;
+  if (
+    restock_threshold !== undefined &&
+    (typeof restock_threshold !== 'number' || restock_threshold < 0)
+  )
+    return false;
+  return true;
+};
+
 // GET /inventory -> returns all inventory items
 router.get('/', async (req, res) => {
   try {
@@ -26,7 +45,7 @@ router.get('/', async (req, res) => {
     res.json({ success: true, data: rows });
   } catch (err) {
     console.error('Failed to retrieve items:', err.message);
-    res.status(500).json({ error: 'Server error.' });
+    res.status(500).json({ success: false, error: 'Server error' });
   }
 });
 
@@ -34,18 +53,19 @@ router.get('/', async (req, res) => {
 router.post('/', async (req, res) => {
   const { name, category, quantity, unit, restock_threshold, supplier } = req.body;
 
-  if (name === undefined || quantity === undefined) {
-    return res.status(400).json({ error: "'name' and 'quantity' are required." });
+  if (!isValidItem(name, quantity, restock_threshold)) {
+    return res.status(400).json({ success: false, error: 'Invalid input data' });
   }
 
   try {
-    const query = `INSERT INTO inventory (name, category, quantity, unit, restock_threshold, supplier)` +
-                  ` VALUES (?, ?, ?, ?, ?, ?)`;
+    const query =
+      `INSERT INTO inventory (name, category, quantity, unit, restock_threshold, supplier)` +
+      ` VALUES (?, ?, ?, ?, ?, ?)`;
     const result = await runAsync(query, [name, category, quantity, unit, restock_threshold, supplier]);
     res.status(201).json({ success: true, data: { id: result.lastID } });
   } catch (err) {
     console.error('Failed to insert item:', err.message);
-    res.status(500).json({ error: 'Server error.' });
+    res.status(500).json({ success: false, error: 'Server error' });
   }
 });
 
@@ -54,20 +74,24 @@ router.put('/:id', async (req, res) => {
   const { id } = req.params;
   const { name, category, quantity, unit, restock_threshold, supplier } = req.body;
 
-  if (name === undefined || quantity === undefined) {
-    return res.status(400).json({ error: "'name' and 'quantity' are required." });
+  if (!isValidItem(name, quantity, restock_threshold)) {
+    return res.status(400).json({ success: false, error: 'Invalid input data' });
   }
 
   try {
+    const existing = await getAsync('SELECT id FROM inventory WHERE id=?', [id]);
+    if (!existing) {
+      return res.status(404).json({ success: false, error: 'Item not found' });
+    }
     const query = `UPDATE inventory SET name=?, category=?, quantity=?, unit=?, restock_threshold=?, supplier=? WHERE id=?`;
     const result = await runAsync(query, [name, category, quantity, unit, restock_threshold, supplier, id]);
     if (result.changes === 0) {
-      return res.status(404).json({ error: 'Item not found.' });
+      return res.status(404).json({ success: false, error: 'Item not found' });
     }
     res.json({ success: true, data: { updated: result.changes } });
   } catch (err) {
     console.error('Failed to update item:', err.message);
-    res.status(500).json({ error: 'Server error.' });
+    res.status(500).json({ success: false, error: 'Server error' });
   }
 });
 
@@ -77,12 +101,12 @@ router.delete('/:id', async (req, res) => {
   try {
     const result = await runAsync('DELETE FROM inventory WHERE id=?', [id]);
     if (result.changes === 0) {
-      return res.status(404).json({ error: 'Item not found.' });
+      return res.status(404).json({ success: false, error: 'Item not found' });
     }
     res.json({ success: true, data: { deleted: result.changes } });
   } catch (err) {
     console.error('Failed to delete item:', err.message);
-    res.status(500).json({ error: 'Server error.' });
+    res.status(500).json({ success: false, error: 'Server error' });
   }
 });
 


### PR DESCRIPTION
## Summary
- add helper `getAsync` and `isValidItem`
- validate input for POST/PUT routes
- check for non-existent items for PUT and DELETE
- return consistent `{ success, data|error }` payloads
- improve error handling with 500 responses

## Testing
- `npm test --silent` in `server`
- `npm test --silent` in `client`

------
https://chatgpt.com/codex/tasks/task_e_687b1c1584008331877880d2368ebab0