### PR TITLE
Highlight low-stock rows

### DIFF
--- a/client/src/InventoryTable.css
+++ b/client/src/InventoryTable.css
@@ -42,3 +42,8 @@
 .error-input {
   border: 1px solid red;
 }
+
+/* Highlight rows that are at or below the restock threshold */
+.low-stock {
+  background-color: #ffcccc;
+}

--- a/client/src/InventoryTable.js
+++ b/client/src/InventoryTable.js
@@ -126,7 +126,15 @@ function InventoryTable({ refreshFlag }) {
           </thead>
           <tbody>
             {items.map((item) => (
-              <tr key={item.id}>
+              <tr
+                key={item.id}
+                className={
+                  item.restock_threshold != null &&
+                  Number(item.quantity) <= Number(item.restock_threshold)
+                    ? 'low-stock'
+                    : ''
+                }
+              >
                 <td>{item.id}</td>
                 <td>{item.name}</td>
                 <td>{item.category}</td>


### PR DESCRIPTION
## Summary
- add a `.low-stock` style for rows that need restock
- mark `<tr>` with the class when quantity is below threshold

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687b26681000833187bf679de1d365e0