### PR TITLE
Align title to top-left

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,5 +1,13 @@
 .App {
-  text-align: center;
+  text-align: left;
+}
+
+.app-header {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 1rem 0;
+  margin-bottom: 1rem;
 }
 
 .App-logo {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -11,7 +11,9 @@ function App() {
 
   return (
     <div className="App">
-      <h1>Office Supply Manager</h1>
+      <header className="app-header">
+        <h1>Office Supply Manager</h1>
+      </header>
       <InventoryTable refreshFlag={refreshFlag} />
     </div>
   );


### PR DESCRIPTION
## Summary
- wrap the main title in a dedicated header element
- add new CSS rules for the `app-header` class
- set the app's text alignment to left

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687b2fc84f848331a443be32929f7317