### PR TITLE
Add tabbed navigation to frontend

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -36,6 +36,24 @@
   color: #61dafb;
 }
 
+.tabs {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.tab {
+  padding: 0.5rem 1rem;
+  background: #f2f2f2;
+  border: none;
+  cursor: pointer;
+}
+
+.tab.active {
+  border-bottom: 2px solid #007bff;
+  background: #e6e6e6;
+}
+
 @keyframes App-logo-spin {
   from {
     transform: rotate(0deg);

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,9 +1,12 @@
 import React, { useState } from 'react';
 import './App.css';
 import InventoryTable from './InventoryTable';
+import Purchases from './Purchases';
+import Trends from './Trends';
 
 function App() {
   const [refreshFlag, setRefreshFlag] = useState(0);
+  const [activeTab, setActiveTab] = useState('Inventory');
 
   const triggerRefresh = () => {
     setRefreshFlag((prev) => prev + 1);
@@ -14,7 +17,31 @@ function App() {
       <header className="app-header">
         <h1>Office Supply Manager</h1>
       </header>
-      <InventoryTable refreshFlag={refreshFlag} />
+      <div className="tabs">
+        <button
+          className={activeTab === 'Inventory' ? 'tab active' : 'tab'}
+          onClick={() => setActiveTab('Inventory')}
+        >
+          Inventory
+        </button>
+        <button
+          className={activeTab === 'Purchases' ? 'tab active' : 'tab'}
+          onClick={() => setActiveTab('Purchases')}
+        >
+          Purchases
+        </button>
+        <button
+          className={activeTab === 'Trends' ? 'tab active' : 'tab'}
+          onClick={() => setActiveTab('Trends')}
+        >
+          Trends
+        </button>
+      </div>
+      <div className="tab-content">
+        {activeTab === 'Inventory' && <InventoryTable refreshFlag={refreshFlag} />}
+        {activeTab === 'Purchases' && <Purchases />}
+        {activeTab === 'Trends' && <Trends />}
+      </div>
     </div>
   );
 }

--- a/client/src/InventoryTable.js
+++ b/client/src/InventoryTable.js
@@ -145,7 +145,6 @@ function InventoryTable({ refreshFlag }) {
 
   return (
     <div className="inventory-table">
-      <h2>Inventory</h2>
       {successMsg && <p className="success-message">{successMsg}</p>}
       <button onClick={fetchItems}>Refresh</button>
       <div className="table-controls">

--- a/client/src/Purchases.js
+++ b/client/src/Purchases.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function Purchases() {
+  return (
+    <div className="purchases-placeholder">
+      <p>This section will handle auto re-stocking and purchasing.</p>
+    </div>
+  );
+}
+
+export default Purchases;

--- a/client/src/Trends.js
+++ b/client/src/Trends.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+function Trends() {
+  return (
+    <div className="trends-placeholder">
+      <div className="trends-graph">Graph will be displayed here</div>
+      <div className="trends-list">
+        List of items showing last purchase date, amount purchased,
+        and projected next purchase will be displayed here.
+      </div>
+    </div>
+  );
+}
+
+export default Trends;


### PR DESCRIPTION
## Summary
- add placeholder pages for Purchases and Trends
- implement tab navigation and active tab styling in App
- remove the old Inventory subtitle and keep search/filter area intact

## Testing
- `npm test --prefix client -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_687b32e2c524833197bf94f0eddfcf23