### PR TITLE
Add interactive range selector for Trends graph

### DIFF
--- a/client/src/Trends.css
+++ b/client/src/Trends.css
@@ -1,0 +1,39 @@
+.trends-container {
+  margin-top: 1rem;
+}
+
+.trends-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.range-toggle {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.range-toggle button {
+  background: #f2f2f2;
+  border: none;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+}
+
+.range-toggle button.active {
+  background: #007bff;
+  color: white;
+}
+
+.trends-placeholder {
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+}
+.x-axis {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+}

--- a/client/src/Trends.js
+++ b/client/src/Trends.js
@@ -1,12 +1,87 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
+import './Trends.css';
+
+const monthlyData = [
+  { label: 'Jan', value: 30 },
+  { label: 'Feb', value: 45 },
+  { label: 'Mar', value: 28 },
+  { label: 'Apr', value: 60 },
+  { label: 'May', value: 80 },
+  { label: 'Jun', value: 75 },
+  { label: 'Jul', value: 90 },
+  { label: 'Aug', value: 65 },
+  { label: 'Sep', value: 70 },
+  { label: 'Oct', value: 95 },
+  { label: 'Nov', value: 85 },
+  { label: 'Dec', value: 100 },
+];
+
+const quarterlyData = [
+  { label: 'Q1', value: 120 },
+  { label: 'Q2', value: 200 },
+  { label: 'Q3', value: 180 },
+  { label: 'Q4', value: 220 },
+];
+
+const yearlyData = [
+  { label: '2021', value: 650 },
+  { label: '2022', value: 720 },
+  { label: '2023', value: 810 },
+  { label: '2024', value: 950 },
+];
 
 function Trends() {
+  const [selectedRange, setSelectedRange] = useState('Monthly');
+
+  const data = useMemo(() => {
+    if (selectedRange === 'Quarterly') return quarterlyData;
+    if (selectedRange === 'Yearly') return yearlyData;
+    return monthlyData;
+  }, [selectedRange]);
+
+  const points = useMemo(() => {
+    const width = 600;
+    const height = 160; // leave some padding for labels
+    const max = Math.max(...data.map((d) => d.value));
+    return data.map((d, i) => {
+      const x = (width / (data.length - 1)) * i;
+      const y = height - (d.value / max) * (height - 20) + 10; // vertical padding
+      return [x, y];
+    });
+  }, [data]);
+
+  const pathData = points
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${p[0]},${p[1]}`)
+    .join(' ');
+
   return (
-    <div className="trends-placeholder">
-      <div className="trends-graph">Graph will be displayed here</div>
-      <div className="trends-list">
-        List of items showing last purchase date, amount purchased,
-        and projected next purchase will be displayed here.
+    <div className="trends-container">
+      <div className="trends-header">
+        <h2>Purchase Trends Overview</h2>
+        <div className="range-toggle">
+          {['Monthly', 'Quarterly', 'Yearly'].map((range) => (
+            <button
+              key={range}
+              className={selectedRange === range ? 'active' : ''}
+              onClick={() => setSelectedRange(range)}
+            >
+              {range}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="trends-placeholder">
+        <svg viewBox="0 0 600 200" width="100%" height="200">
+          <path d={pathData} fill="none" stroke="#007bff" strokeWidth="2" />
+          {points.map((p, i) => (
+            <circle key={i} cx={p[0]} cy={p[1]} r="3" fill="#007bff" />
+          ))}
+        </svg>
+        <div className="x-axis">
+          {data.map((d) => (
+            <span key={d.label}>{d.label}</span>
+          ))}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- create `Trends.css` for layout and styling of the trends view
- implement a simple svg based line graph in `Trends.js`
- add monthly, quarterly and yearly mock data sets
- allow toggling between ranges with active button highlight

## Testing
- `CI=true npm test --prefix client --silent`

------
https://chatgpt.com/codex/tasks/task_e_687bbe3f16508331be43ad2b29ba4bcd