### PR TITLE
Add compare view to trends

### DIFF
--- a/client/src/Trends.css
+++ b/client/src/Trends.css
@@ -31,6 +31,36 @@
   max-width: 600px;
   margin: 0 auto;
 }
+.trends-layout {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.trends-left,
+.trends-right {
+  flex: 1 1 300px;
+}
+.compare-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.item-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.item-table th,
+.item-table td {
+  border: 1px solid #ddd;
+  padding: 0.25rem;
+  text-align: left;
+}
+@media (max-width: 700px) {
+  .trends-layout {
+    flex-direction: column;
+  }
+}
 .x-axis {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- build a flexible layout for purchase trends
- allow selecting multiple items to compare
- draw one line per item in the graph
- show item totals for the selected period

## Testing
- `cd client && npm test --silent --prefix .`

------
https://chatgpt.com/codex/tasks/task_e_687bc5050df88331bfcea3c2333940bd