### PR TITLE
Fix compare dropdown

### DIFF
--- a/client/src/Trends.css
+++ b/client/src/Trends.css
@@ -67,3 +67,47 @@
   font-size: 0.8rem;
   margin-top: 0.25rem;
 }
+
+.dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.dropdown-toggle {
+  padding: 0.3rem 0.6rem;
+  background: #f2f2f2;
+  border: 1px solid #ccc;
+  cursor: pointer;
+}
+
+.dropdown-menu {
+  position: absolute;
+  left: 0;
+  right: 0;
+  z-index: 1;
+  background: #fff;
+  border: 1px solid #ccc;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+.dropdown-menu li {
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+}
+
+.dropdown-menu li.selected {
+  background: #007bff;
+  color: #fff;
+}
+
+.dropdown-menu li:hover {
+  background: #e6e6e6;
+}
+
+.check {
+  margin-left: 0.4rem;
+}


### PR DESCRIPTION
## Summary
- rewrite Trends dropdown to keep it open when toggling compare mode
- highlight selected items and allow multi-select in compare mode

## Testing
- `npm test --silent --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_687bc841df188331913e26d8f88a3669