### PR TITLE
Adjust title spacing

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -2,6 +2,14 @@
   text-align: left;
 }
 
+:root {
+  --tab-width: 100px;
+}
+
+.app-title {
+  margin-left: var(--tab-width);
+}
+
 .app-header {
   display: flex;
   justify-content: flex-start;
@@ -47,6 +55,7 @@
   background: #f2f2f2;
   border: none;
   cursor: pointer;
+  width: var(--tab-width);
 }
 
 .tab.active {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -15,7 +15,7 @@ function App() {
   return (
     <div className="App">
       <header className="app-header">
-        <h1>Office Supply Manager</h1>
+        <h1 className="app-title">Office Supply Manager</h1>
       </header>
       <div className="tabs">
         <button


### PR DESCRIPTION
## Summary
- shift the main title to align after the tabs
- set CSS variable for tab width and reuse it for the title

## Testing
- `npm test --silent` in `client`
- `npm test --silent` in `server`

------
https://chatgpt.com/codex/tasks/task_e_687bec3e41088331b3e544cdce45ff6b