### PR TITLE
Align inventory controls with tabs

### DIFF
--- a/client/src/InventoryTable.css
+++ b/client/src/InventoryTable.css
@@ -59,14 +59,16 @@
   background-color: #ffcccc;
 }
 
-.table-controls {
+.controls-container {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  margin: 0.5rem 0;
+  gap: 10px;
+  margin-left: 1rem;
+  margin-top: 10px;
+  flex-wrap: wrap;
 }
 
-.table-controls input,
-.table-controls select {
+.controls-container input,
+.controls-container select {
   padding: 0.25rem;
 }

--- a/client/src/InventoryTable.js
+++ b/client/src/InventoryTable.js
@@ -146,8 +146,8 @@ function InventoryTable({ refreshFlag }) {
   return (
     <div className="inventory-table">
       {successMsg && <p className="success-message">{successMsg}</p>}
-      <button onClick={fetchItems}>Refresh</button>
-      <div className="table-controls">
+      <div className="controls-container">
+        <button onClick={fetchItems}>Refresh</button>
         <input
           type="text"
           placeholder="Search..."


### PR DESCRIPTION
## Summary
- wrap inventory table control buttons in a new `controls-container`
- style `controls-container` so it lines up with the tabs and wraps on small screens

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687bf46b9c1483318502bc4749e9e281