### PR TITLE
Improve status messages

### DIFF
--- a/client/src/AddItemForm.css
+++ b/client/src/AddItemForm.css
@@ -11,18 +11,23 @@
   padding: 0.25rem;
 }
 
-.error-message {
-  color: red;
-  font-size: 0.85rem;
-}
-
-.success-message {
+.status-message {
   text-align: center;
   width: 100%;
   font-weight: bold;
-  color: green;
   margin-top: 5px;
   animation: fadeIn 0.5s, fadeOut 0.5s 2.5s;
+  opacity: 0;
+  animation-fill-mode: forwards;
+}
+
+.success-message {
+  color: green;
+}
+
+.error-message {
+  color: red;
+  font-size: 0.85rem;
 }
 
 @keyframes fadeIn {

--- a/client/src/AddItemForm.js
+++ b/client/src/AddItemForm.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './AddItemForm.css';
 
 function AddItemForm({ onSuccess }) {
@@ -13,6 +13,16 @@ function AddItemForm({ onSuccess }) {
   const [errors, setErrors] = useState({});
   const [apiError, setApiError] = useState('');
   const [successMsg, setSuccessMsg] = useState('');
+
+  useEffect(() => {
+    if (successMsg || apiError) {
+      const timer = setTimeout(() => {
+        setSuccessMsg('');
+        setApiError('');
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [successMsg, apiError]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -91,7 +101,9 @@ function AddItemForm({ onSuccess }) {
   return (
     <form className="add-item-form" onSubmit={handleSubmit}>
       <h2>Add New Item</h2>
-      {apiError && <div className="error-message">{apiError}</div>}
+      {apiError && (
+        <div className="status-message error-message">{apiError}</div>
+      )}
       <div>
         <label>Name:</label>
         <input
@@ -141,7 +153,9 @@ function AddItemForm({ onSuccess }) {
         <input name="supplier" value={formData.supplier} onChange={handleChange} />
       </div>
       <button type="submit">Add Item</button>
-      {successMsg && <div className="success-message">{successMsg}</div>}
+      {successMsg && (
+        <div className="status-message success-message">{successMsg}</div>
+      )}
     </form>
   );
 }

--- a/client/src/InventoryTable.css
+++ b/client/src/InventoryTable.css
@@ -39,18 +39,23 @@
   cursor: pointer;
 }
 
-.error-message {
-  color: red;
-  font-size: 0.85rem;
-}
-
-.success-message {
+.status-message {
   text-align: center;
   width: 100%;
   font-weight: bold;
-  color: green;
   margin-top: 5px;
   animation: fadeIn 0.5s, fadeOut 0.5s 2.5s;
+  opacity: 0;
+  animation-fill-mode: forwards;
+}
+
+.success-message {
+  color: green;
+}
+
+.error-message {
+  color: red;
+  font-size: 0.85rem;
 }
 
 @keyframes fadeIn {

--- a/client/src/InventoryTable.js
+++ b/client/src/InventoryTable.js
@@ -14,6 +14,16 @@ function InventoryTable({ refreshFlag }) {
   const [filteredData, setFilteredData] = useState([]);
   const [showAddModal, setShowAddModal] = useState(false);
 
+  useEffect(() => {
+    if (successMsg || editApiError) {
+      const timer = setTimeout(() => {
+        setSuccessMsg('');
+        setEditApiError('');
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [successMsg, editApiError]);
+
   const fetchItems = async () => {
     setLoading(true);
     try {
@@ -145,7 +155,9 @@ function InventoryTable({ refreshFlag }) {
 
   return (
     <div className="inventory-table">
-      {successMsg && <div className="success-message">{successMsg}</div>}
+      {successMsg && (
+        <div className="status-message success-message">{successMsg}</div>
+      )}
       <div className="controls-container">
         <button onClick={fetchItems}>Refresh</button>
         <input
@@ -216,7 +228,9 @@ function InventoryTable({ refreshFlag }) {
         <div className="modal">
           <div className="modal-content">
             <h3>Edit Item</h3>
-            {editApiError && <div className="error-message">{editApiError}</div>}
+            {editApiError && (
+              <div className="status-message error-message">{editApiError}</div>
+            )}
             <form onSubmit={handleEditSave}>
               <div>
                 <label>Name:</label>


### PR DESCRIPTION
## Summary
- animate success and error messages with fade-in/out styles
- automatically clear success and error messages
- show styled status messages in the inventory table and item form

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687bf9f130348331883118578fc9073e