### PR TITLE
Wrap status messages in fixed-height container

### DIFF
--- a/client/src/InventoryTable.css
+++ b/client/src/InventoryTable.css
@@ -39,11 +39,18 @@
   cursor: pointer;
 }
 
+.status-message-container {
+  height: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 5px;
+}
+
 .status-message {
   text-align: center;
   width: 100%;
   font-weight: bold;
-  margin-top: 5px;
   animation: fadeIn 0.5s, fadeOut 0.5s 2.5s;
   opacity: 0;
   animation-fill-mode: forwards;

--- a/client/src/InventoryTable.js
+++ b/client/src/InventoryTable.js
@@ -153,11 +153,16 @@ function InventoryTable({ refreshFlag }) {
     };
   }, [showAddModal]);
 
+  const statusMessage = successMsg || editApiError;
+  const statusType = successMsg ? 'success-message' : 'error-message';
+
   return (
     <div className="inventory-table">
-      {successMsg && (
-        <div className="status-message success-message">{successMsg}</div>
-      )}
+      <div className="status-message-container">
+        {statusMessage && (
+          <div className={`status-message ${statusType}`}>{statusMessage}</div>
+        )}
+      </div>
       <div className="controls-container">
         <button onClick={fetchItems}>Refresh</button>
         <input


### PR DESCRIPTION
## Summary
- create a `status-message-container` so space for alerts is reserved
- show success or error messages in this container
- style the container in CSS

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687bfc362f0c833191f997a6f4602f6b