### PR TITLE
Improve layout for Trends view

### DIFF
--- a/client/src/Trends.css
+++ b/client/src/Trends.css
@@ -4,27 +4,35 @@
 
 .trends-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   margin-bottom: 0.5rem;
 }
 
-.range-toggle {
-  display: flex;
-  gap: 0.5rem;
+.trends-subtitle {
+  margin-left: 60px;
 }
 
-.range-toggle button {
+
+.range-toggle-container {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 10px;
+  margin-right: 20px;
+}
+
+.range-toggle-container button {
   background: #f2f2f2;
   border: none;
   padding: 0.3rem 0.6rem;
   cursor: pointer;
+  margin-left: 0.5rem;
 }
 
-.range-toggle button.active {
+.range-toggle-container button.active {
   background: #007bff;
   color: white;
 }
+
 
 .trends-placeholder {
   width: 100%;
@@ -40,10 +48,11 @@
 .trends-right {
   flex: 1 1 300px;
 }
-.compare-controls {
+.trends-toolbar {
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  align-items: center;
+  gap: 10px;
+  margin-left: 10px;
   margin-bottom: 0.5rem;
 }
 .item-table {

--- a/client/src/Trends.js
+++ b/client/src/Trends.js
@@ -171,22 +171,11 @@ function Trends() {
   return (
     <div className="trends-container">
       <div className="trends-header">
-        <h2>Purchase Trends Overview</h2>
-        <div className="range-toggle">
-          {['Monthly', 'Quarterly', 'Yearly'].map((range) => (
-            <button
-              key={range}
-              className={selectedRange === range ? 'active' : ''}
-              onClick={() => setSelectedRange(range)}
-            >
-              {range}
-            </button>
-          ))}
-        </div>
+        <h2 className="trends-subtitle">Purchase Trends Overview</h2>
       </div>
       <div className="trends-layout">
         <div className="trends-left">
-          <div className="compare-controls">
+          <div className="trends-toolbar">
             <div className="dropdown">
               <button
                 className="dropdown-toggle"
@@ -251,8 +240,30 @@ function Trends() {
           </table>
         </div>
         <div className="trends-right">
+          <div className="range-toggle-container">
+            {['Monthly', 'Quarterly', 'Yearly'].map((range) => (
+              <button
+                key={range}
+                className={selectedRange === range ? 'active' : ''}
+                onClick={() => setSelectedRange(range)}
+              >
+                {range}
+              </button>
+            ))}
+          </div>
           <div className="trends-placeholder">
             <svg viewBox="0 0 600 200" width="100%" height="200">
+              {[1, 2, 3, 4].map((i) => (
+                <line
+                  key={i}
+                  x1="0"
+                  y1={i * 40}
+                  x2="600"
+                  y2={i * 40}
+                  stroke="#ccc"
+                  strokeDasharray="5 5"
+                />
+              ))}
               {seriesData.map((series) => (
                 <g key={series.id}>
                   <path


### PR DESCRIPTION
## Summary
- shift purchase trends subtitle
- position range toggle above chart
- add grid lines to trends chart
- align dropdown/checkbox toolbar on left

## Testing
- `npx jest --runInBand` *(fails: SyntaxError: Support for the experimental syntax 'jsx' isn't currently enabled)*

------
https://chatgpt.com/codex/tasks/task_e_687c0611a9d88331af5d2a314173258b