### PR TITLE
Add purchasing table and order modal

### DIFF
--- a/client/src/Purchases.css
+++ b/client/src/Purchases.css
@@ -1,0 +1,81 @@
+.purchases-container table {
+  border-collapse: collapse;
+  width: 100%;
+}
+.purchases-container th,
+.purchases-container td {
+  border: 1px solid #ddd;
+  padding: 8px;
+}
+.purchases-container th {
+  background-color: #f2f2f2;
+}
+
+.controls-container {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: 1rem;
+  margin-top: 10px;
+  flex-wrap: wrap;
+}
+.controls-container input,
+.controls-container select {
+  padding: 0.25rem;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-content {
+  background: white;
+  padding: 1rem;
+  border-radius: 4px;
+  position: relative;
+}
+
+.status-message {
+  text-align: center;
+  width: 100%;
+  font-weight: bold;
+  animation: fadeIn 0.5s, fadeOut 0.5s 2.5s;
+  opacity: 0;
+  animation-fill-mode: forwards;
+  margin-top: 5px;
+}
+
+.success-message {
+  color: green;
+}
+
+.error-message {
+  color: red;
+  font-size: 0.85rem;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}

--- a/client/src/Purchases.js
+++ b/client/src/Purchases.js
@@ -1,9 +1,164 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import './Purchases.css';
 
 function Purchases() {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [orderData, setOrderData] = useState({
+    itemId: '',
+    quantity: '',
+    supplier: '',
+    notes: '',
+  });
+  const [statusMsg, setStatusMsg] = useState('');
+
+  const fetchItems = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('http://localhost:5000/inventory');
+      if (!res.ok) throw new Error('Failed to fetch');
+      const data = await res.json();
+      setItems(data.data || []);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchItems();
+  }, []);
+
+  const lowStockItems = items.filter(
+    (it) =>
+      it.restock_threshold != null &&
+      Number(it.quantity) <= Number(it.restock_threshold)
+  );
+
+  const suggestedQty = (item) => {
+    const thresh = Number(item.restock_threshold);
+    const qty = Number(item.quantity);
+    const suggestion = thresh * 2 - qty;
+    return suggestion > 0 ? suggestion : '';
+  };
+
+  const openModal = () => {
+    setOrderData({
+      itemId: lowStockItems[0]?.id || '',
+      quantity: '',
+      supplier: '',
+      notes: '',
+    });
+    setStatusMsg('');
+    setShowModal(true);
+  };
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setOrderData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const confirmOrder = () => {
+    setShowModal(false);
+    setStatusMsg('Purchase order created!');
+    setTimeout(() => setStatusMsg(''), 3000);
+  };
+
   return (
-    <div className="purchases-placeholder">
-      <p>This section will handle auto re-stocking and purchasing.</p>
+    <div className="purchases-container">
+      <div className="controls-container">
+        <button onClick={fetchItems}>Refresh</button>
+        <button onClick={openModal}>Create Purchase Order</button>
+      </div>
+      {statusMsg && (
+        <div className="status-message success-message">{statusMsg}</div>
+      )}
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <table>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Name</th>
+              <th>Current Quantity</th>
+              <th>Restock Threshold</th>
+              <th>Suggested Order Quantity</th>
+            </tr>
+          </thead>
+          <tbody>
+            {lowStockItems.map((item) => (
+              <tr key={item.id}>
+                <td>{item.id}</td>
+                <td>{item.name}</td>
+                <td>{item.quantity}</td>
+                <td>{item.restock_threshold}</td>
+                <td>{suggestedQty(item)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {showModal && (
+        <div className="modal" onClick={() => setShowModal(false)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h3>Create Purchase Order</h3>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                confirmOrder();
+              }}
+            >
+              <div>
+                <label>Item:</label>
+                <select
+                  name="itemId"
+                  value={orderData.itemId}
+                  onChange={handleChange}
+                >
+                  {items.map((it) => (
+                    <option key={it.id} value={it.id}>
+                      {it.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label>Quantity to order:</label>
+                <input
+                  name="quantity"
+                  type="number"
+                  value={orderData.quantity}
+                  onChange={handleChange}
+                  required
+                />
+              </div>
+              <div>
+                <label>Supplier:</label>
+                <input
+                  name="supplier"
+                  value={orderData.supplier}
+                  onChange={handleChange}
+                />
+              </div>
+              <div>
+                <label>Notes:</label>
+                <textarea
+                  name="notes"
+                  value={orderData.notes}
+                  onChange={handleChange}
+                />
+              </div>
+              <button type="submit">Confirm Order</button>
+              <button type="button" onClick={() => setShowModal(false)}>
+                Cancel
+              </button>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- implement Purchases page with restock table and purchase order modal
- style Purchases component similar to Inventory

## Testing
- `npm test --prefix client -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687c0bb6645483319de893a6475a20c8