### PR TITLE
Add purchase order PDF endpoints and Purchases tab

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/pdfs/*.pdf

--- a/server/db.js
+++ b/server/db.js
@@ -24,11 +24,11 @@ const createInventoryQuery = `CREATE TABLE IF NOT EXISTS inventory (
 // Create purchaseOrders table if it doesn't exist
 const createOrdersQuery = `CREATE TABLE IF NOT EXISTS purchaseOrders (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  date TEXT,
-  item TEXT,
+  itemName TEXT,
   quantity INTEGER,
   supplier TEXT,
-  notes TEXT
+  notes TEXT,
+  orderDate TEXT
 )`;
 
 // Ensure the table exists and populate it with sample data on first run

--- a/server/index.js
+++ b/server/index.js
@@ -33,7 +33,7 @@ const allAsync = (sql, params = []) =>
   });
 
 // Directory for generated PDFs
-const ordersDir = path.join(__dirname, 'purchase_orders');
+const ordersDir = path.join(__dirname, 'pdfs');
 if (!fs.existsSync(ordersDir)) {
   fs.mkdirSync(ordersDir);
 }
@@ -47,14 +47,12 @@ app.use('/inventory', inventoryRoutes);
 
 // POST /api/purchase-orders -> create a purchase order and generate PDF
 app.post('/api/purchase-orders', async (req, res) => {
-  const { itemId, quantity, supplier, notes } = req.body;
+  const { itemName, quantity, supplier, notes, orderDate } = req.body;
   try {
-    const itemRow = await getAsync('SELECT name FROM inventory WHERE id=?', [itemId]);
-    const itemName = itemRow ? itemRow.name : '';
-    const date = new Date().toISOString();
+    const date = orderDate || new Date().toISOString();
     const result = await runAsync(
-      'INSERT INTO purchaseOrders (date, item, quantity, supplier, notes) VALUES (?, ?, ?, ?, ?)',
-      [date, itemName, quantity, supplier, notes]
+      'INSERT INTO purchaseOrders (itemName, quantity, supplier, notes, orderDate) VALUES (?, ?, ?, ?, ?)',
+      [itemName, quantity, supplier, notes, date]
     );
     const id = result.lastID;
 


### PR DESCRIPTION
## Summary
- create `purchaseOrders` table with columns like itemName and orderDate
- generate purchase order PDFs in `server/pdfs`
- implement API endpoints to create/fetch orders
- add Purchases tab UI to list orders and create new ones
- ignore generated PDFs

## Testing
- `npm test` in server (fails: Error: no test specified)
- `CI=true npm test --silent` in client

------
https://chatgpt.com/codex/tasks/task_e_687c175074808331a220ec166a50c7eb