### PR TITLE
Add Vista-like UI theme

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,5 +1,14 @@
+
+body {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: linear-gradient(to bottom, #cfe7ff, #a0e0e0);
+  min-height: 100vh;
+}
+
 .App {
   text-align: left;
+  color: #000;
 }
 
 :root {
@@ -53,15 +62,36 @@
 
 .tab {
   padding: 0.5rem 1rem;
-  background: #f2f2f2;
-  border: none;
+  background: #ffffff;
+  border: 1px solid #ccc;
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
   cursor: pointer;
   width: var(--tab-width);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: background 0.3s;
+}
+
+.tab:hover {
+  background: #e0f0ff;
 }
 
 .tab.active {
-  border-bottom: 2px solid #007bff;
-  background: #e6e6e6;
+  background: #e6f0ff;
+  border-color: #7eb4ea;
+}
+
+button {
+  background: linear-gradient(to bottom, #ffffff, #e6e6e6);
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  padding: 0.4rem 0.8rem;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+button:hover {
+  background: linear-gradient(to bottom, #f0faff, #dbefff);
 }
 
 @keyframes App-logo-spin {

--- a/client/src/InventoryTable.css
+++ b/client/src/InventoryTable.css
@@ -2,12 +2,17 @@
   border-collapse: collapse;
   width: 100%;
 }
-.inventory-table th, .inventory-table td {
-  border: 1px solid #ddd;
+.inventory-table th,
+.inventory-table td {
+  border: 1px solid #ccc;
   padding: 8px;
 }
 .inventory-table th {
-  background-color: #f2f2f2;
+  background: linear-gradient(to bottom, #ffffff, #e7e7e7);
+}
+
+.inventory-table tbody tr:hover {
+  background-color: rgba(173, 216, 230, 0.3);
 }
 
 .modal {
@@ -16,17 +21,19 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.4);
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .modal-content {
-  background: white;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(4px);
   padding: 1rem;
-  border-radius: 4px;
+  border-radius: 8px;
   position: relative;
+  border: 1px solid rgba(255, 255, 255, 0.6);
 }
 
 .close-button {

--- a/client/src/Purchases.css
+++ b/client/src/Purchases.css
@@ -4,11 +4,15 @@
 }
 .purchases-container th,
 .purchases-container td {
-  border: 1px solid #ddd;
+  border: 1px solid #ccc;
   padding: 8px;
 }
 .purchases-container th {
-  background-color: #f2f2f2;
+  background: linear-gradient(to bottom, #ffffff, #e7e7e7);
+}
+
+.purchases-container tbody tr:hover {
+  background-color: rgba(173, 216, 230, 0.3);
 }
 
 .controls-container {
@@ -30,17 +34,19 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.4);
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .modal-content {
-  background: white;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(4px);
   padding: 1rem;
-  border-radius: 4px;
+  border-radius: 8px;
   position: relative;
+  border: 1px solid rgba(255, 255, 255, 0.6);
 }
 
 .status-message {

--- a/client/src/Trends.css
+++ b/client/src/Trends.css
@@ -20,10 +20,6 @@
 }
 
 .range-toggle-container button {
-  background: #f2f2f2;
-  border: none;
-  padding: 0.3rem 0.6rem;
-  cursor: pointer;
   margin-left: 0.5rem;
 }
 
@@ -70,9 +66,16 @@
 }
 .item-table th,
 .item-table td {
-  border: 1px solid #ddd;
+  border: 1px solid #ccc;
   padding: 0.25rem;
   text-align: left;
+}
+.item-table th {
+  background: linear-gradient(to bottom, #ffffff, #e7e7e7);
+}
+
+.item-table tbody tr:hover {
+  background-color: rgba(173, 216, 230, 0.3);
 }
 @media (max-width: 700px) {
   .trends-layout {


### PR DESCRIPTION
## Summary
- add gradient body background and global Segoe UI font
- style tabs and buttons with Vista-like look
- update table, modal, and tab styles across all pages

## Testing
- `npm test --prefix client --silent`
- `npm test --prefix server --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c1a9ea0b08331a87b13d91ec546bf