### PR TITLE
Prevent horizontal overflow

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -120,7 +120,9 @@ button:hover {
   border-radius: 10px;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
   padding: 20px;
-  width: 95%;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 95%;
   margin: 20px auto;
 }
 
@@ -142,8 +144,10 @@ button:hover {
   border-radius: 10px;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
   padding: 15px;
+  box-sizing: border-box;
   width: 100%;
-  margin: 0 auto;
+  max-width: 95%;
+  margin: 20px auto;
   position: relative;
 }
 


### PR DESCRIPTION
## Summary
- adjust `.content-box` and `.chart-container` styles so sections no longer overflow the page

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687c263e9bac8331a09890c36e3639a5