### PR TITLE
Add reorder workflow enhancements

### DIFF
--- a/client/src/Purchases.css
+++ b/client/src/Purchases.css
@@ -71,6 +71,17 @@
   font-size: 0.85rem;
 }
 
+.order-items-table {
+  margin-top: 0.5rem;
+  width: 100%;
+  border-collapse: collapse;
+}
+.order-items-table th,
+.order-items-table td {
+  border: 1px solid #ccc;
+  padding: 4px;
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;

--- a/server/db.js
+++ b/server/db.js
@@ -28,7 +28,8 @@ const createOrdersQuery = `CREATE TABLE IF NOT EXISTS purchaseOrders (
   quantity INTEGER,
   supplier TEXT,
   notes TEXT,
-  orderDate TEXT
+  orderDate TEXT,
+  items TEXT
 )`;
 
 // Ensure the table exists and populate it with sample data on first run
@@ -37,6 +38,10 @@ const createOrdersQuery = `CREATE TABLE IF NOT EXISTS purchaseOrders (
 db.serialize(() => {
   db.run(createInventoryQuery);
   db.run(createOrdersQuery);
+  // Add the items column if it was created before this field existed
+  db.run('ALTER TABLE purchaseOrders ADD COLUMN items TEXT', (err) => {
+    // ignore errors if column already exists
+  });
 
   db.get('SELECT COUNT(*) AS count FROM inventory', (err, row) => {
     if (err) {


### PR DESCRIPTION
## Summary
- highlight low inventory rows in Inventory table
- add reorder item multi-select in Purchases modal
- allow custom items and multiple items per purchase order
- store purchase order items JSON and generate PDFs with all items

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687c2c9cdff08331a217782e83c142d2