### PR TITLE
Fix low-stock row highlighting

### DIFF
--- a/client/src/InventoryTable.css
+++ b/client/src/InventoryTable.css
@@ -109,6 +109,6 @@
 
 /* Highlight rows that are at or below the restock threshold */
 .low-stock {
-  background-color: #ffcccc;
+  background-color: rgba(255, 0, 0, 0.15);
 }
 

--- a/client/src/InventoryTable.js
+++ b/client/src/InventoryTable.js
@@ -31,7 +31,15 @@ function InventoryTable({ refreshFlag, onInventoryChange }) {
       const res = await fetch('http://localhost:5000/inventory');
       if (!res.ok) throw new Error('Failed to fetch');
       const data = await res.json();
-      setItems(data.data || []);
+      const list = (data.data || []).map((it) => ({
+        ...it,
+        // normalize camelCase for easier access in the UI
+        restockThreshold:
+          it.restockThreshold !== undefined
+            ? it.restockThreshold
+            : it.restock_threshold,
+      }));
+      setItems(list);
     } catch (err) {
       console.error(err);
       alert('Error fetching inventory');
@@ -288,8 +296,8 @@ function InventoryTable({ refreshFlag, onInventoryChange }) {
               <tr
                 key={item.id}
                 className={
-                  item.restock_threshold != null &&
-                  Number(item.quantity) <= Number(item.restock_threshold)
+                  item.restockThreshold != null &&
+                  Number(item.quantity) <= Number(item.restockThreshold)
                     ? 'low-stock'
                     : ''
                 }


### PR DESCRIPTION
## Summary
- normalize inventory data to add `restockThreshold`
- highlight low-stock rows using the normalized value
- tweak low-stock background color

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6887bd523df083318586c80eb277fa45