### PR TITLE
Improve login page layout

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -168,3 +168,8 @@ button:hover {
   margin-left: 4px;
   font-size: 0.75em;
 }
+
+.error-msg {
+  color: red;
+  font-size: 0.9rem;
+}

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,6 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
+beforeEach(() => {
+  localStorage.setItem('token', 'test');
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
 test('renders supply manager heading', () => {
   render(<App />);
   const heading = screen.getByText(/office supply manager/i);

--- a/client/src/Auth.css
+++ b/client/src/Auth.css
@@ -1,0 +1,45 @@
+.auth-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  width: 100%;
+}
+
+.auth-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 1.5rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+.auth-container form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.auth-container input {
+  padding: 0.5rem;
+}
+
+.link-btn {
+  background: none;
+  border: none;
+  color: #007bff;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+  font-size: 1rem;
+}
+
+.link-btn:hover {
+  text-decoration: none;
+}

--- a/client/src/Auth.js
+++ b/client/src/Auth.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import './App.css';
+import './Auth.css';
 import { apiFetch } from './api';
 
 function Auth({ onAuth }) {
@@ -27,17 +28,32 @@ function Auth({ onAuth }) {
   };
 
   return (
-    <div className="auth-container">
-      <h2>{isLogin ? 'Login' : 'Register'}</h2>
-      <form onSubmit={handleSubmit}>
-        <input value={username} onChange={(e) => setUsername(e.target.value)} placeholder="Username" />
-        <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" />
-        <button type="submit">{isLogin ? 'Login' : 'Register'}</button>
-      </form>
-      {error && <div className="error-msg">{error}</div>}
-      <button onClick={() => setIsLogin(!isLogin)} className="link-btn">
-        {isLogin ? 'Need an account? Register' : 'Have an account? Login'}
-      </button>
+    <div className="auth-wrapper">
+      <div className="auth-container">
+        <h2>{isLogin ? 'Login' : 'Register'}</h2>
+        <form onSubmit={handleSubmit}>
+          <input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="Username"
+          />
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+          />
+          <button type="submit">{isLogin ? 'Login' : 'Register'}</button>
+        </form>
+        {error && <div className="error-msg">{error}</div>}
+        <button
+          type="button"
+          onClick={() => setIsLogin(!isLogin)}
+          className="link-btn"
+        >
+          {isLogin ? 'Need an account? Register' : 'Have an account? Login'}
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- center login form in viewport
- stack login elements vertically with spacing
- restyle link button
- include error message styling
- adjust test setup for login page

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688a8129751c8331827393cdb85a9490