### PR TITLE
Add user avatar dropdown menu

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -27,9 +27,9 @@ body {
 
 .app-header {
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
   align-items: center;
-  padding: 1rem 0;
+  padding: 1rem;
   margin-bottom: 1rem;
 }
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,35 +6,38 @@ import Trends from './Trends';
 import Reports from './Reports';
 import Auth from './Auth';
 import AdminPanel from './AdminPanel';
+import UserAvatar from './UserAvatar';
 
 function App() {
   const [inventoryFlag, setInventoryFlag] = useState(0);
   const [activeTab, setActiveTab] = useState('Inventory');
   const [trendsMode, setTrendsMode] = useState('Quantity');
   const [role, setRole] = useState(localStorage.getItem('role') || '');
+  const [username, setUsername] = useState(localStorage.getItem('username') || '');
 
   const triggerInventoryChange = () => {
     setInventoryFlag((prev) => prev + 1);
   };
 
   if (!localStorage.getItem('token')) {
-    return <Auth onAuth={(r) => setRole(r)} />;
+    return <Auth onAuth={(r, u) => { setRole(r); setUsername(u); }} />;
   }
 
   return (
     <div className="App">
       <header className="app-header">
         <h1 className="app-title">Office Supply Manager</h1>
-        <button
-          className="logout-btn"
-          onClick={() => {
+        <UserAvatar
+          username={username}
+          role={role}
+          onLogout={() => {
             localStorage.removeItem('token');
             localStorage.removeItem('role');
+            localStorage.removeItem('username');
             window.location.reload();
           }}
-        >
-          Logout
-        </button>
+          onUserManagement={() => setActiveTab('Admin')}
+        />
       </header>
       <div className="tabs">
         <button

--- a/client/src/Auth.js
+++ b/client/src/Auth.js
@@ -21,7 +21,8 @@ function Auth({ onAuth }) {
     if (res.ok && data.token) {
       localStorage.setItem('token', data.token);
       localStorage.setItem('role', data.role);
-      onAuth(data.role);
+      localStorage.setItem('username', username);
+      onAuth(data.role, username);
     } else {
       setError(data.error || 'Failed');
     }

--- a/client/src/UserAvatar.css
+++ b/client/src/UserAvatar.css
@@ -1,0 +1,62 @@
+.user-avatar-container {
+  position: relative;
+}
+
+.user-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(to bottom, #e3f2ff, #b7cde8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: bold;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  user-select: none;
+}
+
+.avatar-menu {
+  position: absolute;
+  right: 0;
+  margin-top: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(4px);
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  animation: fadeSlide 0.15s ease-out;
+  z-index: 10;
+  min-width: 150px;
+}
+
+@keyframes fadeSlide {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.avatar-menu button {
+  background: transparent;
+  border: none;
+  width: 100%;
+  text-align: left;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.avatar-menu button:hover {
+  background: #e6f0ff;
+}
+
+.menu-divider {
+  height: 1px;
+  background: rgba(0, 0, 0, 0.1);
+  margin: 4px 0;
+}

--- a/client/src/UserAvatar.js
+++ b/client/src/UserAvatar.js
@@ -1,0 +1,44 @@
+import React, { useState, useRef, useEffect } from 'react';
+import './UserAvatar.css';
+
+function UserAvatar({ username, role, onLogout, onUserManagement }) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef();
+
+  useEffect(() => {
+    function handleClick(e) {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    }
+    if (open) {
+      document.addEventListener('mousedown', handleClick);
+    }
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const initial = (username || '').charAt(0).toUpperCase();
+
+  return (
+    <div className="user-avatar-container" ref={containerRef}>
+      <div className="user-avatar" onClick={() => setOpen(!open)}>
+        {initial || '?'}
+      </div>
+      {open && (
+        <div className="avatar-menu">
+          <button type="button">Account</button>
+          <button type="button">Settings</button>
+          {role === 'admin' && (
+            <button type="button" onClick={() => { onUserManagement(); setOpen(false); }}>
+              User Management
+            </button>
+          )}
+          <div className="menu-divider" />
+          <button type="button" onClick={onLogout}>Log Out</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default UserAvatar;


### PR DESCRIPTION
## Summary
- add storage of username during authentication
- track username in App state
- add `UserAvatar` component with dropdown menu
- update header layout and styling

## Testing
- `CI=true npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_688a86dcd9cc8331b81729ece3f53290