### PR TITLE
Add business registration and roles

### DIFF
--- a/client/src/Auth.js
+++ b/client/src/Auth.js
@@ -7,20 +7,28 @@ function Auth({ onAuth }) {
   const [isLogin, setIsLogin] = useState(true);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [accountType, setAccountType] = useState('business');
+  const [businessName, setBusinessName] = useState('');
   const [error, setError] = useState('');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     const url = isLogin ? 'http://localhost:5000/api/login' : 'http://localhost:5000/api/register';
+    const payload = isLogin
+      ? { username, password }
+      : { username, password, accountType, businessName };
     const res = await apiFetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password })
+      body: JSON.stringify(payload)
     });
     const data = await res.json();
     if (res.ok && data.token) {
       localStorage.setItem('token', data.token);
       localStorage.setItem('role', data.role);
+      if (data.businessId !== undefined) {
+        localStorage.setItem('businessId', data.businessId);
+      }
       localStorage.setItem('username', username);
       onAuth(data.role, username);
     } else {
@@ -44,6 +52,21 @@ function Auth({ onAuth }) {
             onChange={(e) => setPassword(e.target.value)}
             placeholder="Password"
           />
+          {!isLogin && (
+            <>
+              <select value={accountType} onChange={(e) => setAccountType(e.target.value)}>
+                <option value="business">Business</option>
+                <option value="personal">Personal</option>
+              </select>
+              {accountType === 'business' && (
+                <input
+                  value={businessName}
+                  onChange={(e) => setBusinessName(e.target.value)}
+                  placeholder="Business Name"
+                />
+              )}
+            </>
+          )}
           <button type="submit">{isLogin ? 'Login' : 'Register'}</button>
         </form>
         {error && <div className="error-msg">{error}</div>}


### PR DESCRIPTION
## Summary
- enable business registration workflow
- create businesses table and link users
- store business information in tokens
- restrict user management to same business
- extend registration form with account type and business name

## Testing
- `npm --prefix server test` *(fails: Error: no test specified)*
- `npm --prefix client run test --silent -- -u`


------
https://chatgpt.com/codex/tasks/task_e_688ade8b2614833196972f08aeda5b70