### PR TITLE
Update admin access via user dropdown

### DIFF
--- a/client/src/AdminPanel.js
+++ b/client/src/AdminPanel.js
@@ -3,6 +3,11 @@ import { apiFetch } from './api';
 import './App.css';
 
 function AdminPanel() {
+  const role = localStorage.getItem('role');
+  if (role !== 'admin') {
+    return null;
+  }
+
   const [users, setUsers] = useState([]);
   const [error, setError] = useState('');
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -64,14 +64,6 @@ function App() {
         >
           Reports
         </button>
-        {role === 'admin' && (
-          <button
-            className={activeTab === 'Admin' ? 'tab active' : 'tab'}
-            onClick={() => setActiveTab('Admin')}
-          >
-            Admin
-          </button>
-        )}
       </div>
       <div className="tab-content">
         {activeTab === 'Inventory' && (

--- a/client/src/UserAvatar.css
+++ b/client/src/UserAvatar.css
@@ -58,5 +58,6 @@
 .menu-divider {
   height: 1px;
   background: rgba(0, 0, 0, 0.1);
-  margin: 4px 0;
+  margin-top: 8px;
+  margin-bottom: 4px;
 }


### PR DESCRIPTION
## Summary
- remove Admin button from main navigation
- add spacing in dropdown divider and keep User Management link for admins
- guard AdminPanel access with a simple role check

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688ae3d741148331a727411f5352e766