### PR TITLE
Fix hooks in AdminPanel

### DIFF
--- a/client/src/AdminPanel.js
+++ b/client/src/AdminPanel.js
@@ -1,15 +1,12 @@
 import React, { useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
 import { apiFetch } from './api';
 import './App.css';
 
 function AdminPanel() {
-  const role = localStorage.getItem('role');
-  if (role !== 'admin') {
-    return null;
-  }
-
   const [users, setUsers] = useState([]);
   const [error, setError] = useState('');
+  const role = localStorage.getItem('role');
 
   const load = async () => {
     const res = await apiFetch('http://localhost:5000/api/users');
@@ -19,6 +16,10 @@ function AdminPanel() {
   };
 
   useEffect(() => { load(); }, []);
+
+  if (role !== 'admin') {
+    return <Navigate to="/" />;
+  }
 
   const changeRole = async (id, role) => {
     await apiFetch(`http://localhost:5000/api/users/${id}/role`, {


### PR DESCRIPTION
## Summary
- call hooks at top of `AdminPanel`
- use `<Navigate>` for non-admin redirect

## Testing
- `npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_688ae65216448331b5b5786fce042e70