### PR TITLE
Normalize purchase order schema and fix PO rendering

### DIFF
--- a/client/src/utils/format.js
+++ b/client/src/utils/format.js
@@ -1,0 +1,12 @@
+export function formatDate(iso, { withTime = false } = {}) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  if (!withTime) return `${y}-${m}-${day}`;
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${y}-${m}-${day} ${hh}:${mm}`;
+}


### PR DESCRIPTION
## Summary
- normalize purchase order items when creating and updating records
- render purchase orders and drafts per item with explicit columns and formatted dates
- add small date formatting helper

## Testing
- `cd client && npm test -- --watchAll=false`
- `cd server && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aa160a0b1c83319a8895321f7e89ec