### PR TITLE
Fix Purchase Orders flow: no draft on submit, proper status transitions, and correct totals in Reports

### DIFF
--- a/client/src/Reports.js
+++ b/client/src/Reports.js
@@ -21,7 +21,14 @@ function Reports() {
     const url = `/api/reports/purchase-orders?startDate=${startDate}&endDate=${endDate}`;
     const res = await apiFetch(url);
     const data = await res.json();
-    setOrders(data.data || []);
+    const list = (data.data || []).map((o) => ({
+      ...o,
+      total: (o.items || []).reduce(
+        (s, it) => s + Number(it.quantity || 0) * Number(it.price || 0),
+        0
+      ),
+    }));
+    setOrders(list);
   };
 
   const fetchItems = async () => {
@@ -128,7 +135,7 @@ function Reports() {
       Supplier: o.supplier || '',
       Notes: o.notes || '',
       Status: o.status || '',
-      Total: (o.items || []).reduce((s, it) => s + Number(it.price || 0), 0)
+      Total: o.total
     }));
     const itemsRows = [];
     orders.forEach((o) => (o.items || []).forEach((it) => itemsRows.push({
@@ -204,9 +211,9 @@ function Reports() {
                 </span>
               )}
             </th>
-            <th onClick={() => handleOrderSort('price')}>
+            <th onClick={() => handleOrderSort('total')}>
               Total Cost
-              {sortOrders.key === 'price' && (
+              {sortOrders.key === 'total' && (
                 <span className="sort-indicator">
                   {sortOrders.direction === 'asc' ? '▲' : '▼'}
                 </span>
@@ -221,7 +228,7 @@ function Reports() {
               <td>{o.supplier}</td>
               <td>{o.items ? o.items.map((i) => i.itemName).join(', ') : o.itemName}</td>
               <td>{o.items ? o.items.map((i) => i.quantity).join(', ') : o.quantity}</td>
-              <td>{formatCurrency(o.price)}</td>
+              <td>{formatCurrency(o.total)}</td>
             </tr>
           ))}
         </tbody>

--- a/client/src/localdb/store.js
+++ b/client/src/localdb/store.js
@@ -89,7 +89,7 @@ export const PurchaseOrders = {
       id: uuid(),
       orderDate: data.orderDate || now,
       notes: data.notes || '',
-      status: data.status || 'final',
+      status: data.status === 'draft' ? 'draft' : 'final',
       items,
       last_modified: now,
     };
@@ -105,14 +105,15 @@ export const PurchaseOrders = {
       : patch.orderItems
         ? patch.orderItems.map(normalizePOItem)
         : cur.items;
-    const rec = {
+    const next = {
       ...cur,
       ...patch,
       items,
+      status: patch.status === 'draft' ? 'draft' : patch.status === 'final' ? 'final' : cur.status,
       last_modified: new Date().toISOString(),
     };
-    await db.put('purchaseOrders', rec);
-    return rec;
+    await db.put('purchaseOrders', next);
+    return next;
   },
   async remove(id) { await (await getDB()).delete('purchaseOrders', id); }
 };


### PR DESCRIPTION
## Summary
- Ensure purchase orders persist only as `draft` or `final` and allow status promotion.
- Track and update draft orders without duplication, filtering by status on the Purchases page.
- Calculate per-order totals in reports and Excel exports.

## Testing
- `npm test -- --watchAll=false` (client)
- `npm test` (server) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aa28cf08f08331aa1be4e062bf5c36