### PR TITLE
Aggregate purchase order view and export improvements

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -50,8 +50,9 @@ code {
 
 .mono {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-variant-numeric: tabular-nums;
 }
 
-td.mono, th.mono {
-  font-variant-numeric: tabular-nums;
+th input[type="checkbox"] {
+  transform: translateY(1px);
 }

--- a/client/src/utils/format.js
+++ b/client/src/utils/format.js
@@ -10,3 +10,7 @@ export function formatDate(iso, { withTime = false } = {}) {
   const mm = String(d.getMinutes()).padStart(2, '0');
   return `${y}-${m}-${day} ${hh}:${mm}`;
 }
+
+export function money(n) {
+  return `$${Number(n || 0).toFixed(2)}`;
+}


### PR DESCRIPTION
## Summary
- Aggregate purchase orders into single rows with totals and supplier summaries
- Enable selecting purchase orders for report export and include unit prices
- Add money formatting utility and minor checkbox/monospace styling

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68aa2e2d657c8331a09c3c899311a62f