### PR TITLE
feat: add y-axis with formatted ticks for trends chart

### DIFF
--- a/client/src/Trends.css
+++ b/client/src/Trends.css
@@ -126,3 +126,4 @@
 }
 .checkbox-row { display:flex; align-items:center; gap:8px; padding:4px 2px; }
 .compare-toggle { margin-left:8px; user-select:none; }
+.y-axis-label { font-size:12px; opacity:0.9; }


### PR DESCRIPTION
## Summary
- show y-axis with dynamic label and tick formatting for quantity vs. price
- format tooltip values using shared money() helper
- add small style for y-axis label

## Testing
- `npm test --prefix client -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68aa3281e8a48331a21314a9812ad1c5