### PR TITLE
Rename app to Inventory Manager

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -30,7 +30,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Inventory Manager</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Inventory Manager",
+  "name": "Inventory Manager",
   "icons": [
     {
       "src": "favicon.ico",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './App.css';
 import InventoryTable from './InventoryTable';
 import Purchases from './Purchases';
@@ -11,6 +11,10 @@ function App() {
   const [activeTab, setActiveTab] = useState('Inventory');
   const [trendsMode, setTrendsMode] = useState('Quantity');
 
+  useEffect(() => {
+    document.title = 'Inventory Manager';
+  }, []);
+
   const triggerInventoryChange = () => {
     setInventoryFlag((prev) => prev + 1);
   };
@@ -18,7 +22,7 @@ function App() {
   return (
     <div className="App app-root">
       <header className="app-header">
-        <h1 className="app-title">Office Supply Manager</h1>
+        <h1 className="app-title">Inventory Manager</h1>
       </header>
       <div className="tabs">
         <button

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -9,8 +9,8 @@ afterEach(() => {
   localStorage.clear();
 });
 
-test('renders supply manager heading', () => {
+test('renders inventory manager heading', () => {
   render(<App />);
-  const heading = screen.getByText(/office supply manager/i);
+  const heading = screen.getByText(/inventory manager/i);
   expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- Rename header and document title to "Inventory Manager" and ensure tab title updates on mount
- Update HTML and PWA manifest to use "Inventory Manager"
- Adjust tests to expect new app name

## Testing
- `npm test -- --watchAll=false` in `client`
- `npm test` in `server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5d4a4f2883319be1cc9d69b63afe